### PR TITLE
6 python39 enum issue

### DIFF
--- a/BeamGage/Python/BeamGage-Py-Example.py
+++ b/BeamGage/Python/BeamGage-Py-Example.py
@@ -61,8 +61,8 @@ def main():
 
     # Background calibrate the camera (don't forget to block the beam)
     beamgage.data_source.ultracal()
-    cal_status = beamgage.data_source.ultracal_status()
-    print(cal_status.name)
+    cal_status = beamgage.data_source.ultracal_status
+    print(cal_status.ToString())
 
     # todo this isn't getting called despite getting registered to the event
     # def newframe_handler(source, args):

--- a/BeamGage/Python/BeamGage-Py-Example.py
+++ b/BeamGage/Python/BeamGage-Py-Example.py
@@ -82,7 +82,7 @@ def main():
     beamgage.data_source.start()
     time.sleep(5)
     status = beamgage.data_source.status
-    print(status)
+    print(status.ToString())
 
     # Obtaining results and frame data should be event driven or with the data source stopped
     data = beamgage.get_frame_data()

--- a/BeamGage/Python/BeamGage-Py-Example.py
+++ b/BeamGage/Python/BeamGage-Py-Example.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-""" A Python 3.7 example client for BeamGage Professional v6.16
+""" A Python 3.10 example client for BeamGage Professional v6.21
 
 This module is intended as a client program for the purposes of utilizing the BeamGage Professional
 Automation Interface.  The BeamGage Automation Interface is an API which interfaces with the BeamGage beam profiling
@@ -37,10 +37,10 @@ import time
 import beamgagepy
 
 __author__ = "Russ Leikis"
-__copyright__ = "Copyright 2022, Ophir-Spiricon, LLC"
+__copyright__ = "Copyright 2024, Ophir-Spiricon, LLC"
 __credits__ = ["Russ Leikis"]
 __license__ = "MIT"
-__version__ = "0.3"
+__version__ = "0.4"
 __maintainer__ = "Russ Leikis"
 __email__ = "russ.leikis@mksinst.com"
 __status__ = "Alpha"

--- a/BeamGage/Python/beamgagepy.py
+++ b/BeamGage/Python/beamgagepy.py
@@ -927,7 +927,7 @@ class PositionalStabilityResults:
 
 ###
 # These are likely unneeded now that the Python.Net enum handling has changed in v3.0 and later.
-# It is possible to directly use the enums from the .NET interface.
+# It is possible to directly reference the enums from the Spiricon.Automation namespace.
 ###
 class ApertureShape(enum.Enum):
     Rectangle = 0

--- a/BeamGage/Python/beamgagepy.py
+++ b/BeamGage/Python/beamgagepy.py
@@ -144,10 +144,11 @@ class BeamGagePy:
         del self.power_energy_results
         del self.spatial_results
         del self.frame_results
-        del self.frameevents
+        # del self.frameevents
 
         self.beamgage.Instance.Shutdown()
         self.beamgage.Dispose()
+        del self.beamgage
 
     def get_frame_data(self):
         """ Get the current Frame

--- a/BeamGage/Python/beamgagepy.py
+++ b/BeamGage/Python/beamgagepy.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-""" A Python 3.7 wrapper class for BeamGage Professional v6.16
+""" A Python 3.10 wrapper class for BeamGage Professional v6.21
 
 This module is not intended to be run at the Python command line but is instead accessed by a secondary program
 module for the purposes of utilizing the BeamGage Professional Automation Interface.  The BeamGage Automation
@@ -68,10 +68,10 @@ if sys.version_info[0:2] != (3, 10):
     raise Exception('Requires python 3.10')
 
 __author__ = "Russ Leikis"
-__copyright__ = "Copyright 2022, Ophir-Spiricon, LLC"
+__copyright__ = "Copyright 2024, Ophir-Spiricon, LLC"
 __credits__ = ["Russ Leikis"]
 __license__ = "MIT"
-__version__ = "0.3"
+__version__ = "0.4"
 __maintainer__ = "Russ Leikis"
 __email__ = "russ.leikis@mksinst.com"
 __status__ = "Alpha"
@@ -79,7 +79,7 @@ __status__ = "Alpha"
 
 # main wrapper class
 class BeamGagePy:
-    """ A Python 3.7 wrapper class for BeamGage Professional v6.16
+    """ A Python 3.10 wrapper class for BeamGage Professional v6.21
 
     Attributes:
         current_frame (IAFrame):
@@ -923,8 +923,12 @@ class PositionalStabilityResults:
     def disable(self, result_name):
         self.beamgage.PositionalStabilityResults(result_name)
 
-
 # enumerations listed alphabetically """
+
+###
+# These are likely unneeded now that the Python.Net enum handling has changed in v3.0 and later.
+# It is possible to directly use the enums from the .NET interface.
+###
 class ApertureShape(enum.Enum):
     Rectangle = 0
     Ellipse = 1

--- a/BeamGage/Python/beamgagepy.py
+++ b/BeamGage/Python/beamgagepy.py
@@ -64,8 +64,8 @@ import clr
 import ctypes
 
 import sys
-if sys.version_info[0:2] != (3, 4):
-    raise Exception('Requires python 3.4')
+if sys.version_info[0:2] != (3, 10):
+    raise Exception('Requires python 3.10')
 
 __author__ = "Russ Leikis"
 __copyright__ = "Copyright 2022, Ophir-Spiricon, LLC"
@@ -105,7 +105,7 @@ class BeamGagePy:
         Returns:
             object: An instantiated AutomatedBeamGage object, all interfaces are served via its properties
         """
-        # the class constructor automatically instantiates a BeamGage instance        
+        # the class constructor automatically instantiates a BeamGage instance
         import Spiricon.Automation as SpA
         self.beamgage = SpA.AutomatedBeamGage(instance_name, show_gui)
 
@@ -178,6 +178,8 @@ class DataSource:
         Returns:
             None:
         """
+        import Spiricon.Automation as SpA
+        self.spa = SpA
         self.beamgage = bg_instance
         self.beamgage.data_source = bg_instance.DataSource
 
@@ -260,7 +262,7 @@ class DataSource:
             Enum: A CalibrationStatus enumeration value.
         """
         status = self.beamgage.Calibration.Status
-        return CalibrationStatus(status)
+        return status
 
     def ignore_beam(self):
         """ In conjunction with the CalibrationStatus.BeamDetected status, instructs the analyzer to ignore the signal
@@ -333,8 +335,8 @@ class DataSource:
         Returns:
              list[float]: A list of floats which describe the current exposure range.
         """
-        return [self.beamgage.EGB.RangeMin(EGBDesignator.Exposure.value),
-                self.beamgage.EGB.RangeMax(EGBDesignator.Exposure.value)]
+        return [self.beamgage.EGB.RangeMin(self.spa.EGBDesignator.EXPOSURE),
+                self.beamgage.EGB.RangeMax(self.spa.EGBDesignator.EXPOSURE)]
 
     @property
     def exposure_increment(self) -> float:
@@ -343,7 +345,7 @@ class DataSource:
         Returns:
              float: The current increment value for the exposure setting.
         """
-        return self.beamgage.EGB.Increment(EGBDesignator.Exposure.value)
+        return self.beamgage.EGB.Increment(self.spa.EGBDesignator.EXPOSURE)
 
     @property
     def exposure_units(self) -> str:
@@ -352,7 +354,7 @@ class DataSource:
         Returns:
              str: A string value which describes the units applicable to the exposure setting.
         """
-        return self.beamgage.EGB.Units(EGBDesignator.Exposure.value)
+        return self.beamgage.EGB.Units(self.spa.EGBDesignator.EXPOSURE)
 
     @property
     def exposure(self):
@@ -368,12 +370,12 @@ class DataSource:
         Returns:
              float: A float value which represents the current exposure setting of the data source.
         """
-        return self.beamgage.EGB.Get(EGBDesignator.Exposure.value)
+        return self.beamgage.EGB.Get(self.spa.EGBDesignator.EXPOSURE)
 
     @exposure.setter
     def exposure(self, value):
         if isinstance(value, float):
-            self.beamgage.EGB.Set(EGBDesignator.Exposure.value, value)
+            self.beamgage.EGB.Set(self.spa.EGBDesignator.EXPOSURE, value)
         else:
             raise Exception("Argument for value must be a float")
 
@@ -384,8 +386,8 @@ class DataSource:
         Returns:
             list[float]: A list of floats which describe the current gain range.
         """
-        return [self.beamgage.EGB.RangeMin(EGBDesignator.Gain.value),
-                self.beamgage.EGB.RangeMax(EGBDesignator.Gain.value)]
+        return [self.beamgage.EGB.RangeMin(self.spa.EGBDesignator.GAIN),
+                self.beamgage.EGB.RangeMax(self.spa.EGBDesignator.GAIN)]
 
     @property
     def gain_increment(self):
@@ -394,7 +396,7 @@ class DataSource:
         Returns:
              float: The current increment value for the gain setting.
         """
-        return self.beamgage.EGB.Increment(EGBDesignator.Gain.value)
+        return self.beamgage.EGB.Increment(self.spa.EGBDesignator.GAIN)
 
     @property
     def gain_units(self):
@@ -403,7 +405,7 @@ class DataSource:
         Returns:
              str: A string value which describes the units applicable to the gain setting.
         """
-        return self.beamgage.EGB.Units(EGBDesignator.Gain.value)
+        return self.beamgage.EGB.Units(self.spa.EGBDesignator.GAIN)
 
     @property
     def gain(self):
@@ -418,11 +420,11 @@ class DataSource:
         Returns:
             float: A float value which represents the current gain setting of the data source.
         """
-        return self.beamgage.EGB.Get(EGBDesignator.Gain.value)
+        return self.beamgage.EGB.Get(self.spa.EGBDesignator.GAIN)
 
     @gain.setter
     def gain(self, value: float):
-        self.beamgage.EGB.Set(EGBDesignator.Gain.value, value)
+        self.beamgage.EGB.Set(self.spa.EGBDesignator.GAIN, value)
 
     @property
     def black_level_range(self):
@@ -431,8 +433,8 @@ class DataSource:
         Returns:
              list[float]: A list of floats which describe the current black level range.
         """
-        return [self.beamgage.EGB.RangeMin(EGBDesignator.BlackLevel.value),
-                self.beamgage.EGB.RangeMax(EGBDesignator.BlackLevel.value)]
+        return [self.beamgage.EGB.RangeMin(self.spa.EGBDesignator.BLACKLEVEL),
+                self.beamgage.EGB.RangeMax(self.spa.EGBDesignator.BLACKLEVEL)]
 
     @property
     def black_level_increment(self):
@@ -441,7 +443,7 @@ class DataSource:
         Returns:
             float: The current increment value for the black level setting.
         """
-        return self.beamgage.EGB.Increment(EGBDesignator.BlackLevel.value)
+        return self.beamgage.EGB.Increment(self.spa.EGBDesignator.BLACKLEVEL)
 
     @property
     def black_level_units(self):
@@ -450,7 +452,7 @@ class DataSource:
         Returns:
              str: A string value which describes the units applicable to the black level setting.
         """
-        return self.beamgage.EGB.Units(EGBDesignator.BlackLevel.value)
+        return self.beamgage.EGB.Units(self.spa.EGBDesignator.BLACKLEVEL)
 
     @property
     def black_level(self):
@@ -464,11 +466,11 @@ class DataSource:
         Returns:
              float: A float value which represents the current gain setting of the data source.
         """
-        return self.beamgage.EGB.Get(EGBDesignator.BlackLevel.value)
+        return self.beamgage.EGB.Get(self.spa.EGBDesignator.BLACKLEVEL)
 
     @black_level.setter
     def black_level(self, value: float):
-        self.beamgage.EGB.Set(EGBDesignator.BlackLevel.value, value)
+        self.beamgage.EGB.Set(self.spa.EGBDesignator.BLACKLEVEL, value)
 
     @property
     def trigger_delay_range(self):

--- a/BeamGage/Python/beamgagepy.py
+++ b/BeamGage/Python/beamgagepy.py
@@ -216,7 +216,7 @@ class DataSource:
              object: A DataSourceStatus enumeration value.
         """
         status = self.beamgage.DataSource.Status
-        return DataSourceStatus(status)
+        return status
 
     def start(self):
         """ Starts the data acquisition of the data source.

--- a/BeamGage/Python/beamgagepy.py
+++ b/BeamGage/Python/beamgagepy.py
@@ -565,7 +565,7 @@ class Partition:
     def delete_partition(self, string_name):
         self.beamgage.Partition.Delete(string_name)
 
-    def move_partition(self, string_name):
+    def move_partition(self, center_x, center_y, width, height, string_name):
         self.beamgage.Partition.Move(center_x, center_y, width, height, string_name)
 
     def rename_partition(self, string_name, old_string_name):


### PR DESCRIPTION
- Python.Net v3.0 changes their handling of enums causing some necessary changes in this example
- Resolved two minor bugs
  -  The move_partitions method signature was incomplete
  - Resolved an exception from the clean-up of the frameevents reference.  Omitted that line as that implementation is currently omitted.